### PR TITLE
Create unranked-kc-tracker

### DIFF
--- a/plugins/unranked-kc-tracker
+++ b/plugins/unranked-kc-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/Erishion-Games-LLC/Runelite-Unranked-KC-Tracker-Plugin.git
+commit=
+author=Erishion Games LLC


### PR DESCRIPTION
An easy way to see KC and other values not tracked on the High scores.

Values are easy to fake, so prefer to use the high score values when available.

If a boss is highlighted in orange, that boss is being tracked on the high scores and you should use the value on the high scores instead.